### PR TITLE
Disable treesitter indentation

### DIFF
--- a/config/.config/nvim/lua/base/plugins/treesitter.lua
+++ b/config/.config/nvim/lua/base/plugins/treesitter.lua
@@ -30,6 +30,7 @@ return {
 
       indent = {
         enable = true,
+        disable = { "ruby" },
       },
 
       highlight = {


### PR DESCRIPTION
There's a known issue where treesitter's indentation exhibits undesirable behavior e.g. lines with `.` get undented as `.end` is considered a function call. I'm disabling the feature until I can find a suitable workaround.

https://github.com/nvim-treesitter/nvim-treesitter/issues/3363