### PR TITLE
Add `fzf` configuration to `.zshrc`

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -36,3 +36,5 @@ autoload -Uz compinit && compinit
 . $HOME/.asdf/asdf.sh
 
 compctl -g '~/.teamocil/*(:t:r)' teamocil
+
+[[ -f ~/.fzf.zsh ]] && source ~/.fzf.zsh


### PR DESCRIPTION
FZF `PATH` and key bindings are configurable via a generated `.fzf.zsh`.