### PR TITLE
Manually set Mason PATH to `append`

### DIFF
--- a/config/.config/nvim/lua/base/plugins/lsp.lua
+++ b/config/.config/nvim/lua/base/plugins/lsp.lua
@@ -8,7 +8,12 @@ return {
   },
 
   config = function()
-    require("mason").setup()
+    -- Set PATH config to 'append' to ensure system packages are prioritized over
+    -- ones installed by Mason e.g. `rust-analyzer`.
+    require("mason").setup({
+      PATH = "append"
+    })
+
     require("mason-lspconfig").setup({
       ensure_installed = {
         "lua_ls",


### PR DESCRIPTION
The default PATH setting is set to `prepend` which will always prioritize packages installed by Mason. This isn't the most convenient when trying to switch versions of tools e.g. rust-analyzer due to bugs or compatibility issues.

Related: https://github.com/neovim/neovim/issues/30985