### PR TITLE
Configure endwise with treesitter 

### DIFF
--- a/config/.config/nvim/lua/base/plugins/treesitter.lua
+++ b/config/.config/nvim/lua/base/plugins/treesitter.lua
@@ -1,6 +1,10 @@
 return {
   "nvim-treesitter/nvim-treesitter",
 
+  dependencies = {
+    "RRethy/nvim-treesitter-endwise"
+  },
+
   build = ":TSUpdate",
 
   config = function()
@@ -35,7 +39,11 @@ return {
 
       highlight = {
         enable = true,
-      }
+      },
+
+      endwise = {
+        enable = true,
+      },
     })
   end
 }

--- a/config/.config/nvim/lua/base/plugins/treesitter.lua
+++ b/config/.config/nvim/lua/base/plugins/treesitter.lua
@@ -34,7 +34,6 @@ return {
 
       indent = {
         enable = true,
-        disable = { "ruby" },
       },
 
       highlight = {
@@ -45,5 +44,7 @@ return {
         enable = true,
       },
     })
+
+    vim.cmd('autocmd FileType ruby setlocal indentkeys-=.')
   end
 }

--- a/config/.config/nvim/lua/base/plugins/vim-endwise.lua
+++ b/config/.config/nvim/lua/base/plugins/vim-endwise.lua
@@ -1,1 +1,0 @@
-return { "tpope/vim-endwise" }


### PR DESCRIPTION
After tinkering with a few treesitter options, it appears endwise with
proper indentation can be achieved with a plugin that mirrors tpope's
`vim-endwise`.