### PR TITLE
Manually bind Option + up/down key

### DIFF
--- a/zsh/.zsh/bindings.zsh
+++ b/zsh/.zsh/bindings.zsh
@@ -1,0 +1,2 @@
+bindkey '^[[1;3A' end-of-line
+bindkey '^[[1;3B' beginning-of-line

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -25,6 +25,7 @@ path=(
 # Allow commands to pass through to applications
 stty -ixon
 
+source ~/.zsh/bindings.zsh
 source ~/.zsh/prompt.zsh
 source ~/.zsh/utils.zsh
 


### PR DESCRIPTION
There's probably a better way to do this! As of now, SSHing into a box causes Option + Up/Down to interpret the ANSI escape sequences incorrectly, resulting in a `3A` or `3B` getting printed.