### PR TITLE
Set emac mode and bind backward/forward

### DIFF
--- a/zsh/.zsh/bindings.zsh
+++ b/zsh/.zsh/bindings.zsh
@@ -1,2 +1,6 @@
+bindkey -e
+
 bindkey '^[[1;3A' end-of-line
 bindkey '^[[1;3B' beginning-of-line
+bindkey '^[[1;3D' backward-word
+bindkey '^[[1;3C' forward-word


### PR DESCRIPTION
`emac` mode by default will register option + L/R as word movement. Bind the option + L/R keys explicitly as a fallback.